### PR TITLE
Use -x instead of --exclude to zip command to facilitate old versions

### DIFF
--- a/lib/buildpack/packager/package.rb
+++ b/lib/buildpack/packager/package.rb
@@ -105,9 +105,9 @@ module Buildpack
       def zip_files(source_dir, zip_file_path, excluded_files)
         exclude_list = excluded_files.map do |file|
           if file.chars.last == '/'
-            "--exclude=#{file}* --exclude=*/#{file}*"
+            "-x #{file}* -x */#{file}*"
           else
-            "--exclude=#{file} --exclude=*/#{file}"
+            "-x #{file} -x */#{file}"
           end
         end.join(' ')
         `cd #{source_dir} && zip -r #{zip_file_path} ./ #{exclude_list}`

--- a/lib/buildpack/packager/package.rb
+++ b/lib/buildpack/packager/package.rb
@@ -105,9 +105,9 @@ module Buildpack
       def zip_files(source_dir, zip_file_path, excluded_files)
         exclude_list = excluded_files.map do |file|
           if file.chars.last == '/'
-            "-x #{file}* -x */#{file}*"
+            "-x #{file}\\* -x \\*/#{file}\\*"
           else
-            "-x #{file} -x */#{file}"
+            "-x #{file} -x \\*/#{file}"
           end
         end.join(' ')
         `cd #{source_dir} && zip -r #{zip_file_path} ./ #{exclude_list}`


### PR DESCRIPTION
My current client works in a controlled environment and due to security controls, it is very difficult to upgrade internal linux tools. Currently, `buildpack-packager --cached` commands fail on this machine due to the fact that their version of `zip` is so old (v2.31), it does not support the `--exclude` parameter. However, it does support `-x`, which newer versions support as well, with the same basic syntax. This PR switches --exclude to -x to facilitate older versions of zip.