### PR TITLE
Allow dependency urls with parameters

### DIFF
--- a/lib/buildpack/packager/package.rb
+++ b/lib/buildpack/packager/package.rb
@@ -64,7 +64,7 @@ module Buildpack
       private
 
       def uri_cache_path uri
-        uri.gsub(/[:\/]/, '_')
+        uri.gsub(/[:\/\?&]/, '_')
       end
 
       def manifest

--- a/spec/unit/packager/package_spec.rb
+++ b/spec/unit/packager/package_spec.rb
@@ -88,6 +88,7 @@ module Buildpack
       describe '#download_dependencies' do
         let(:local_cache_dir) { 'local_cache_dir' }
         let(:dependency_dir) { File.join('hello_dir', 'dependencies') }
+        let(:url_with_parameters) { 'http://some.cdn/with?parameters=true&secondParameter=present' }
 
         before do
           allow(dependency).to receive(:[])
@@ -143,6 +144,11 @@ module Buildpack
             expect(packager).to receive(:download_file)
             packager.download_dependencies([dependency], local_cache_dir, dependency_dir)
           end
+        end
+
+        it 'translates ? and & characters in the url to underscores' do
+          package = Package.new
+          expect(package.send(:uri_cache_path, url_with_parameters)).to eq("http___some.cdn_with_parameters=true_secondParameter=present")
         end
       end
 


### PR DESCRIPTION
Adds the ability to translate urls which include parameters.
Ex:
When the url of the dependency is "https://go.microsoft.com/fwlink/?LinkID=798405" this will be translated to "https___go.microsoft.com_fwlink__LinkID=798405" now so that it is a valid filename which does not need to be escaped.

Related to cloudfoundry-community/dotnet-core-buildpack#65