### PR TITLE
Add Windows support

### DIFF
--- a/lib/buildpack/packager.rb
+++ b/lib/buildpack/packager.rb
@@ -24,6 +24,10 @@ module Buildpack
 
         package.build_dependencies(temp_dir) if options[:mode] == :cached
 
+        Dir.chdir(temp_dir) do
+          package.run_pre_package
+        end
+
         package.build_zip_file(temp_dir)
       end
 

--- a/lib/buildpack/packager/manifest_schema.yml
+++ b/lib/buildpack/packager/manifest_schema.yml
@@ -83,3 +83,6 @@ mapping:
          "version":
            type: text
            required:  yes
+  "pre_package":
+    type: str
+    required: no

--- a/lib/buildpack/packager/manifest_schema.yml
+++ b/lib/buildpack/packager/manifest_schema.yml
@@ -64,7 +64,7 @@ mapping:
            required:  yes
            sequence:
              - type: str
-               enum: [ lucid64, cflinuxfs2 ]
+               enum: [ lucid64, cflinuxfs2, windows2012R2 ]
   "exclude_files":
     type:      seq
     required:  yes

--- a/lib/buildpack/packager/package.rb
+++ b/lib/buildpack/packager/package.rb
@@ -70,6 +70,12 @@ module Buildpack
         Shellwords.escape(File.join(options[:root_dir], zip_file_name))
       end
 
+      def run_pre_package
+        if manifest['pre_package'] && !Kernel.system(manifest['pre_package'])
+          raise "Failed to run pre_package script: #{manifest['pre_package']}"
+        end
+      end
+
       private
 
       def uri_without_credentials(uri_string)

--- a/spec/integration/buildpack/packager_spec.rb
+++ b/spec/integration/buildpack/packager_spec.rb
@@ -450,5 +450,36 @@ module Buildpack
         end
       end
     end
+
+    describe 'pre package script' do
+      let(:buildpack_mode) { :uncached }
+
+      before do
+        FileUtils.mkdir_p(File.join(buildpack_dir, 'scripts'))
+        script_path = File.join(buildpack_dir, 'scripts/run.sh')
+        File.write(script_path, 'mkdir .cloudfoundry && touch .cloudfoundry/hwc.exe')
+        File.chmod(0755, script_path)
+      end
+
+      it 'runs the pre package script if specified' do
+        create_manifest(pre_package: 'scripts/run.sh')
+        Packager.package(options)
+
+        zip_file_path = File.join(buildpack_dir, 'sample_buildpack-v1.2.3.zip')
+        zip_contents = get_zip_contents(zip_file_path)
+
+        expect(zip_contents).to include('.cloudfoundry/hwc.exe')
+      end
+
+      it 'does not run the pre package script if not specified' do
+        create_manifest(pre_package: nil)
+        Packager.package(options)
+
+        zip_file_path = File.join(buildpack_dir, 'sample_buildpack-v1.2.3.zip')
+        zip_contents = get_zip_contents(zip_file_path)
+
+        expect(zip_contents).not_to include('.cloudfoundry/hwc.exe')
+      end
+    end
   end
 end

--- a/spec/unit/packager/package_spec.rb
+++ b/spec/unit/packager/package_spec.rb
@@ -191,6 +191,42 @@ module Buildpack
           packager.build_zip_file('hello_dir')
         end
       end
+
+      describe '#run_pre_package' do
+        context 'when manifest has pre_package set' do
+          let(:manifest) do
+            { pre_package: 'scripts/build.sh' }
+          end
+
+          context 'when the pre package script succeeds' do
+            it 'does not raise an error' do
+              allow(Kernel).to receive(:system)
+                .with('scripts/build.sh')
+                .and_return(true)
+
+              packager.run_pre_package
+              expect(Kernel).to have_received(:system)
+            end
+          end
+
+          context 'when the pre package script fails' do
+            it 'raises an error' do
+              allow(Kernel).to receive(:system)
+                .with('scripts/build.sh')
+                .and_return(false)
+              expect { packager.run_pre_package }.to raise_error('Failed to run pre_package script: scripts/build.sh')
+            end
+          end
+        end
+
+        context 'when manifest does not have pre_package set' do
+          it 'does nothing' do
+            expect(Kernel).not_to receive(:system)
+
+            packager.run_pre_package
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Hey Buildpacks Team,

This PR adds Windows support to the buildpack-packager. First, we add the windows2012R2 stack as a recognized stack. We also extend the manifest with a `pre_package` directive, which allows for arbitrary code to be run before packaging. For the hwc-buildpack, this is used to compile the `compile` script which uses the new libbuildpack.