### PR TITLE
Add windows2016 as a valid stack for manifest dependencies

### DIFF
--- a/lib/buildpack/packager/manifest_schema.yml
+++ b/lib/buildpack/packager/manifest_schema.yml
@@ -67,7 +67,7 @@ mapping:
            required:  yes
            sequence:
              - type: str
-               enum: [ lucid64, cflinuxfs2, windows2012R2 ]
+               enum: [ lucid64, cflinuxfs2, windows2012R2, windows2016 ]
   "exclude_files":
     type:      seq
     required:  yes

--- a/spec/fixtures/manifests/manifest_windows.yml
+++ b/spec/fixtures/manifests/manifest_windows.yml
@@ -1,0 +1,13 @@
+---
+language: hwc
+dependencies:
+- name: hwc
+  version: 3.0.0
+  uri: https://buildpacks.cloudfoundry.org/dependencies/hwc/hwc-3.0.0-windows-amd64-acb65777.zip
+  md5: acb65777be759df87d7d288146d592f7
+  cf_stacks:
+  - windows2012R2
+  - windows2016
+pre_package: scripts/build.sh
+
+exclude_files: []

--- a/spec/unit/manifest_validator_spec.rb
+++ b/spec/unit/manifest_validator_spec.rb
@@ -30,6 +30,15 @@ describe Buildpack::ManifestValidator do
         expect(validator.errors).to be_empty
       end
     end
+
+    context 'with a manifest with windows stacks' do
+      let (:manifest_file_name) { 'manifest_windows.yml' }
+
+      it 'reports valid manifests correctly' do
+        expect(validator.valid?).to be(true)
+        expect(validator.errors).to be_empty
+      end
+    end
   end
 
   context 'with a manifest with an invalid md5 key' do


### PR DESCRIPTION
This will allow the HWC buildpack to eventually work on windows2016 stack