### PR TITLE
Change caching behavior for file:/// paths.

### DIFF
--- a/lib/buildpack/packager/package.rb
+++ b/lib/buildpack/packager/package.rb
@@ -80,12 +80,16 @@ module Buildpack
       private
 
       def uri_without_credentials(uri_string)
-        uri = URI(uri_string)
-        if uri.userinfo
-          uri.user = "-redacted-" if uri.user
-          uri.password = "-redacted-" if uri.password
+        if uri_string.start_with?("file:")
+          uri_string
+        else
+          uri = URI(uri_string)
+          if uri.userinfo
+            uri.user = "-redacted-" if uri.user
+            uri.password = "-redacted-" if uri.password
+          end
+          uri.to_s
         end
-        uri.to_s.sub("file:", "file://")
       end
 
       def uri_cache_path uri

--- a/spec/unit/packager/package_spec.rb
+++ b/spec/unit/packager/package_spec.rb
@@ -168,6 +168,15 @@ module Buildpack
             expect(package.send(:uri_without_credentials, url_with_credentials)).to eq("http://-redacted-@some.cdn/with")
           end
         end
+
+        context 'local url without credentials does not have to much slashs' do
+          let(:url_with_credentials) { 'file:///my/local/path' }
+
+          it 'redacts the credential in the resulting file path' do
+            package = Package.new
+            expect(package.send(:uri_without_credentials, url_with_credentials)).to eq("file:///my/local/path")
+          end
+        end
       end
 
       describe '#build_zip_file' do


### PR DESCRIPTION
Ruby changed in on of their recent versions its behavior of URI for files.
They introduced URI::File which also allows hostnames for files.
This result in a different behavior for the to string method, because it returns with file:///.
To avoid this behavior and since there are no credentials for file:, it can be returned directly.
See also for reference the new URI::File:
https://github.com/ruby/ruby/commit/04883f12c8944922117482d4d446502e5d5d3413

See also the previous pull request: https://github.com/cloudfoundry/buildpack-packager/pull/18