### PR TITLE
Mark SUSE rootfs as supported

### DIFF
--- a/lib/buildpack/packager/manifest_schema.yml
+++ b/lib/buildpack/packager/manifest_schema.yml
@@ -67,7 +67,7 @@ mapping:
            required:  yes
            sequence:
              - type: str
-               enum: [ lucid64, cflinuxfs2, cflinuxfs3, windows2012R2, windows2016 ]
+               enum: [ lucid64, cflinuxfs2, cflinuxfs3, windows2012R2, windows2016, opensuse42, sle12 ]
   "exclude_files":
     type:      seq
     required:  yes


### PR DESCRIPTION
The buildpack-packager has a static list of supported stacks so it does not work with our stack.

We need to maintain a fork of the packager just to add two enum entries. I think the best is to get rid of the `enum` and just check that some stack is defined as a string.
If this is no option for you it would be great if you could add our stacks.

Thanks in advance.