### PR TITLE
Add cflinuxfs4 to buildpack packager

### DIFF
--- a/lib/buildpack/packager/manifest_schema.yml
+++ b/lib/buildpack/packager/manifest_schema.yml
@@ -76,7 +76,7 @@ mapping:
            required:  yes
            sequence:
              - type: str
-               enum: [ lucid64, cflinuxfs2, cflinuxfs3, windows2012R2, windows2016, opensuse42, sle12, sle15 ]
+               enum: [ lucid64, cflinuxfs2, cflinuxfs3, cflinuxfs4, windows2012R2, windows2016, opensuse42, sle12, sle15 ]
          "dependencies":
            type:      seq
            required:  no


### PR DESCRIPTION
Without this change, the packager fails with:
```
The manifest does not conform to the schema:
	- manifest.yml:63:3 [/dependencies/0/cf_stacks/0] 'cflinuxfs4': invalid 0 value.
```